### PR TITLE
Fixed broken link

### DIFF
--- a/tutorials/getting_started/using_as_a_library_pt1.md
+++ b/tutorials/getting_started/using_as_a_library_pt1.md
@@ -575,5 +575,5 @@ allennlp train \
 When we do this, we get to around 80% validation accuracy after a few epochs of training.
 
 To see how to make predictions and build a demo for our new model, see the
-[Making Predictions and Creating a Demo](making_predictions_and_creating_a_demo.md) tutorial, which continues
+[Making Predictions and Creating a Demo](using_as_a_library_pt2.md) tutorial, which continues
 where this tutorial leaves off.


### PR DESCRIPTION
"Using AllenNLP as a Library (Part 1) - Datasets and Models" links to part 2, "Using AllenNLP as a Library (Part 2) - Predictions and Demos" but the link was broken and needed fixing.